### PR TITLE
Improve the turn-key experience

### DIFF
--- a/components/haskell/dep/react/git.json
+++ b/components/haskell/dep/react/git.json
@@ -1,7 +1,0 @@
-{
-  "url": "ssh://git@code.obsidian.systems/ryantrinkle/react",
-  "rev": "aea4f3b654ad528443e39762cd772c030323644a",
-  "sha256": "0rh7skvm0lbpv9ggwm5ipqsx9hdm58h22vns7j8vi7n6361mkpc0",
-  "private": false,
-  "fetchSubmodules": false
-}

--- a/components/haskell/dep/react/github.json
+++ b/components/haskell/dep/react/github.json
@@ -1,0 +1,7 @@
+{
+  "owner": "obsidiansystems",
+  "repo": "react",
+  "private": false,
+  "rev": "3aee4ea4c61fbe893491d0e60454b33359e569c3",
+  "sha256": "1f9w924y5g98bwd252pdav24qk9nlghk9bzl01p2ryk4cc09bib4"
+}

--- a/components/haskell/dep/react/thunk.nix
+++ b/components/haskell/dep/react/thunk.nix
@@ -1,17 +1,12 @@
 # DO NOT HAND-EDIT THIS FILE
-let fetch = {url, rev, branch ? null, sha256 ? null, fetchSubmodules ? false, private ? false, ...}:
-  let realUrl = let firstChar = builtins.substring 0 1 url; in
-    if firstChar == "/" then /. + url
-    else if firstChar == "." then ./. + url
-    else url;
-  in if !fetchSubmodules && private then builtins.fetchGit {
-    url = realUrl; inherit rev;
-    ${if branch == null then null else "ref"} = branch;
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
   } else (import (builtins.fetchTarball {
   url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
   sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
-}) {}).fetchgit {
-    url = realUrl; inherit rev sha256;
+}) {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
   };
-  json = builtins.fromJSON (builtins.readFile ./git.json);
+  json = builtins.fromJSON (builtins.readFile ./github.json);
 in fetch json

--- a/components/haskell/dep/reflex-react/git.json
+++ b/components/haskell/dep/reflex-react/git.json
@@ -1,8 +1,0 @@
-{
-  "url": "ssh://git@code.obsidian.systems/ryantrinkle/reflex-react",
-  "rev": "0e9475dc4a888a5e649a18b9a45b3bb5b07f970c",
-  "sha256": "04x02jg1avlbyiz472ngz0cxxly4vb0knksyq5pz6yrd3crnhjwh",
-  "private": true,
-  "fetchSubmodules": false,
-  "branch": "main"
-}

--- a/components/haskell/dep/reflex-react/github.json
+++ b/components/haskell/dep/reflex-react/github.json
@@ -1,0 +1,7 @@
+{
+  "owner": "obsidiansystems",
+  "repo": "reflex-react",
+  "private": false,
+  "rev": "e000fed5880355975c19489f0e368332dfbd41db",
+  "sha256": "1fpnvy1ikisnjnfz1q6s75rgknckspi14qa5v2n9znprpa52mi8w"
+}

--- a/components/haskell/dep/reflex-react/thunk.nix
+++ b/components/haskell/dep/reflex-react/thunk.nix
@@ -1,17 +1,12 @@
 # DO NOT HAND-EDIT THIS FILE
-let fetch = {url, rev, branch ? null, sha256 ? null, fetchSubmodules ? false, private ? false, ...}:
-  let realUrl = let firstChar = builtins.substring 0 1 url; in
-    if firstChar == "/" then /. + url
-    else if firstChar == "." then ./. + url
-    else url;
-  in if !fetchSubmodules && private then builtins.fetchGit {
-    url = realUrl; inherit rev;
-    ${if branch == null then null else "ref"} = branch;
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
   } else (import (builtins.fetchTarball {
   url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
   sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
-}) {}).fetchgit {
-    url = realUrl; inherit rev sha256;
+}) {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
   };
-  json = builtins.fromJSON (builtins.readFile ./git.json);
+  json = builtins.fromJSON (builtins.readFile ./github.json);
 in fetch json

--- a/package-lock.json
+++ b/package-lock.json
@@ -2873,9 +2873,9 @@
       }
     },
     "node_modules/next-haskell": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-haskell/-/next-haskell-1.0.0.tgz",
-      "integrity": "sha512-twLVSnILxhC/nzf1JSqpzVwlzLMR6nrJ/FIZDXr5sjWRvXsuTf/O0zO/KSLTk7Ht1Do+efwZeghdQDiHyi+PVg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/next-haskell/-/next-haskell-1.0.1.tgz",
+      "integrity": "sha512-l4ZRMVrZLc7Vg2RuiYzPVi7ehf12ipKU+XZ4ymIdwDfp+wx3u22xjvxz5KuPl8hgCB+RjQINZx8fsTZu00WYYA==",
       "dependencies": {
         "@ryantrinkle/haskell-loader": "1.x"
       }

--- a/shell.nix
+++ b/shell.nix
@@ -4,5 +4,6 @@ with nixpkgs;
 mkShell {
   buildInputs = [
     nodejs
+    ghcid
   ];
 }


### PR DESCRIPTION
* pick up some leftover dependencies off github instead of private repo
* upgrade `next-haskell` to 1.0.1
* provide `ghcid` so the example would not depend on `ghcid` in PATH and provide it instead